### PR TITLE
Typed rewards and environment description

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -36,6 +36,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "atom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,7 +65,7 @@ dependencies = [
  "rand 0.4.2 (git+https://github.com/LinearZoetrope/rand?branch=serde)",
  "rayon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlua 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "scaii_defs 0.3.0 (git+https://github.com/SCAII/SCAII?branch=dev)",
+ "scaii_defs 0.4.0",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "shred 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -180,15 +188,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "coco"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +216,37 @@ dependencies = [
 name = "crossbeam"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "curl"
@@ -513,6 +543,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "memoffset"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "mime"
@@ -957,7 +992,7 @@ name = "rayon"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rayon-core 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -966,19 +1001,19 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon-core 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1038,8 +1073,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "scaii_defs"
-version = "0.3.0"
-source = "git+https://github.com/SCAII/SCAII?branch=dev#8984abf1420f70919fb4d374577562508b3e4345"
+version = "0.4.0"
 dependencies = [
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1203,7 +1237,7 @@ version = "0.2.0"
 source = "git+https://github.com/slide-rs/specs#489a1ca54b6e664591497278a9d4739c22f209d7"
 dependencies = [
  "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.12.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.12.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1227,7 +1261,7 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.12.12"
+version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1478,6 +1512,7 @@ dependencies = [
 "checksum alga 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9a9749cf5cfdca30ac35de67358fb24e2d26a88e2819ee83efb794a09f0b421b"
 "checksum approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08abcc3b4e9339e33a3d0a5ed15d84a687350c05689d825e0f6655eef9e76a94"
 "checksum arrayvec 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)" = "06f59fe10306bb78facd90d28c2038ad23ffaaefa85bac43c8a434cde383334f"
+"checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 "checksum atom 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4cd7b80cba09d9c6679f5ac66af2e5eb9c17fa1b914f142d690b069ba51eacaf"
 "checksum backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbbf59b1c43eefa8c3ede390fcc36820b4999f7914104015be25025e0d62af2"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
@@ -1494,11 +1529,13 @@ dependencies = [
 "checksum cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "deaf9ec656256bb25b404c51ef50097207b9cbb29c933d31f92cae5a8a0ffee0"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-"checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
 "checksum crc 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd5d02c0aac6bd68393ed69e00bbc2457f3e89075c6349db7189618dc4ddc1d7"
 "checksum crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "24ce9782d4d5c53674646a6a4c1863a21a8fc0cb649b3c94dfc16e45071dea19"
+"checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
+"checksum crossbeam-epoch 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "59796cc6cbbdc6bb319161349db0c3250ec73ec7fcb763a51065ec4e2e158552"
+"checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum curl 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b70fd6394677d3c0e239ff4be6f2b3176e171ffd1c23ffdc541e78dea2b8bb5e"
 "checksum curl-sys 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f46e49c7125131f5afaded06944d6888b55cbdf8eba05dae73c954019b907961"
 "checksum derivative 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67b3d6d0e84e53a5bdc263cc59340541877bb541706a191d762bfac6a481bdde"
@@ -1537,6 +1574,7 @@ dependencies = [
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
 "checksum matrixmultiply 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "cac1a66eab356036af85ea093101a14223dc6e3f4c02a59b7d572e5b93270bf7"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
+"checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum miniz_oxide 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aaa2d3ad070f428fffbd7d3ca2ea20bb0d8cffe9024405c44e1840bc1418b398"
 "checksum miniz_oxide_c_api 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "92d98fdbd6145645828069b37ea92ca3de225e000d80702da25c20d3584b38a5"
@@ -1584,7 +1622,7 @@ dependencies = [
 "checksum rawpointer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebac11a9d2e11f2af219b8b8d833b76b1ea0e054aa0e8d8e9e4cbde353bdf019"
 "checksum rayon 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b614fe08b6665cb9a231d07ac1364b0ef3cb3698f1239ee0c4c3a88a524f54c8"
 "checksum rayon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed02d09394c94ffbdfdc755ad62a132e94c3224a8354e78a1200ced34df12edf"
-"checksum rayon-core 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e64b609139d83da75902f88fd6c01820046840a18471e4dfcd5ac7c0f46bea53"
+"checksum rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d24ad214285a7729b174ed6d3bcfcb80177807f959d95fafd5bfc5c4f201ac8"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "5be5347bde0c48cfd8c3fdc0766cdfe9d8a755ef84d620d6794c778c91de8b2b"
 "checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
@@ -1593,7 +1631,6 @@ dependencies = [
 "checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
-"checksum scaii_defs 0.3.0 (git+https://github.com/SCAII/SCAII?branch=dev)" = "<none>"
 "checksum schannel 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "acece75e0f987c48863a6c792ec8b7d6c4177d4a027f8ccc72f849794f437016"
 "checksum scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f417c22df063e9450888a7561788e9bd46d3bb3c1466435b4eccb903807f147d"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
@@ -1615,7 +1652,7 @@ dependencies = [
 "checksum specs-derive 0.2.0 (git+https://github.com/slide-rs/specs)" = "<none>"
 "checksum syn 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)" = "58fd09df59565db3399efbba34ba8a2fec1307511ebd245d0061ff9d42691673"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-"checksum syn 0.12.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9e1c669ed757c0ebd04337f6a5bb972d05e0c08fe2540dd3ee3dd9e4daf1604c"
+"checksum syn 0.12.13 (registry+https://github.com/rust-lang/crates.io-index)" = "517f6da31bc53bf080b9a77b29fbd0ff8da2f5a2ebd24c73c2238274a94ac7cb"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f73eebdb68c14bcb24aef74ea96079830e7fa7b31a6106e42ea7ee887c1e134e"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Zoe Juozapaitis <Jragonmiris@gmail.com>"]
 crate-type = ["dylib", "rlib"]
 
 [dependencies]
-scaii_defs = {version="0.3", git = "https://github.com/SCAII/SCAII", branch="dev"}
+scaii_defs = {version="0.5", git = "https://github.com/SCAII/SCAII", branch="reward_types"}
 rlua  = "0.9"
 serde = "1"
 serde_derive = "1"

--- a/backend/lua/tower_example.lua
+++ b/backend/lua/tower_example.lua
@@ -57,7 +57,9 @@ function sky_init()
             body="triangle",
             base_len=2.0,
         },
+        kill_reward=0,
         death_penalty=-100,
+        death_type="agent_death",
         damage_recv_penalty=0,
         damage_deal_reward=0,
         speed=40.0,
@@ -76,6 +78,8 @@ function sky_init()
         },
         can_move=false,
         kill_reward=150,
+        kill_type="enemy_kill",
+        death_type="friendly_kill",
         damage_recv_penalty=0,
         damage_deal_reward=0,
         attack_range=0.3,
@@ -93,6 +97,8 @@ function sky_init()
         },
         can_move=false,
         kill_reward=1000,
+        kill_type="enemy_kill",
+        death_type="friendly_kill",
         damage_recv_penalty=0,
         damage_deal_reward=0,
         attack_range=0.3,
@@ -105,6 +111,7 @@ function sky_init()
         factions=factions,
         victory_reward=0,
         failure_penalty=0,
+        reward_types={"agent_death","friendly_kill","enemy_kill"},
     }
 end
 

--- a/backend/src/engine/resources/mod.rs
+++ b/backend/src/engine/resources/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use super::FactionId;
 use super::components::{AttackSensor, CollisionHandle, Color, Hp, Pos, Shape};
@@ -60,6 +60,7 @@ pub(super) fn register_world_resources(world: &mut World) {
     world.add_resource(Skip(false, None));
     world.add_resource(SerializeBytes::default());
     world.add_resource(LuaPath(None));
+    world.add_resource(RewardTypes::default());
 }
 
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -117,6 +118,11 @@ pub struct UnitType {
     pub attack_range: f64,
     pub attack_damage: f64,
     pub attack_delay: f64,
+
+    pub death_type: String,
+    pub dmg_recv_type: String,
+    pub dmg_deal_type: String,
+    pub kill_type: String,
 }
 
 impl Default for UnitType {
@@ -130,6 +136,10 @@ impl Default for UnitType {
             death_penalty: 0.0,
             damage_deal_reward: None,
             damage_recv_penalty: None,
+            death_type: "death".to_string(),
+            dmg_recv_type: "dmg_recvd".to_string(),
+            dmg_deal_type: "dmg_dealt".to_string(),
+            kill_type: "kill".to_string(),
             speed: 20.0,
             attack_range: 10.0,
             attack_delay: 1.0,
@@ -288,3 +298,20 @@ pub struct SerializeBytes(pub Vec<u8>);
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 pub struct LuaPath(pub Option<String>);
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+pub struct RewardTypes(pub HashSet<String>);
+
+impl Default for RewardTypes {
+    fn default() -> Self {
+        let mut map = HashSet::new();
+        map.insert("death".to_string());
+        map.insert("kill".to_string());
+        map.insert("dmg_dealt".to_string());
+        map.insert("dmg_recvd".to_string());
+        map.insert("victory".to_string());
+        map.insert("defeat".to_string());
+
+        RewardTypes(map)
+    }
+}

--- a/backend/src/engine/systems/lua/userdata.rs
+++ b/backend/src/engine/systems/lua/userdata.rs
@@ -2,6 +2,8 @@ use rlua::{UserData, UserDataMethods};
 
 use engine::components::FactionId;
 
+use std::collections::HashMap;
+
 use rand::Rng;
 
 pub struct UserDataRng<R: Rng + 'static> {
@@ -20,15 +22,21 @@ impl<R: Rng + 'static> UserData for UserDataRng<R> {
     }
 }
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Debug)]
+#[derive(Clone, PartialEq, Default, Debug)]
 pub struct UserDataWorld {
     pub victory: Option<FactionId>,
+    pub rewards: HashMap<String, f64>,
 }
 
 impl UserData for UserDataWorld {
     fn add_methods(methods: &mut UserDataMethods<Self>) {
         methods.add_method_mut("victory", |_, this, faction: usize| {
             this.victory = Some(FactionId(faction));
+            Ok(())
+        });
+
+        methods.add_method_mut("emit_reward", |_, this, (reward, r_type): (f64, String)| {
+            *this.rewards.entry(r_type).or_insert(0.0) += reward;
             Ok(())
         });
     }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -177,7 +177,6 @@ impl<'a, 'b> Module for Context<'a, 'b> {
         use scaii_defs::protos::scaii_packet::SpecificMsg;
         use scaii_defs::protos::Cfg;
         use scaii_defs::protos::cfg::WhichModule;
-        use util;
 
         let src = &packet.src;
 
@@ -186,7 +185,8 @@ impl<'a, 'b> Module for Context<'a, 'b> {
                 which_module: Some(WhichModule::BackendCfg(ref backend_cfg)),
             })) => {
                 let out = self.configure(backend_cfg);
-                self.awaiting_msgs.push(util::ack_msg());
+                let mm = self.rts.init();
+                self.awaiting_msgs.push(mm);
                 out
             }
             Some(SpecificMsg::ResetEnv(true)) => {

--- a/backend/src/util/mod.rs
+++ b/backend/src/util/mod.rs
@@ -29,6 +29,7 @@ fn seed() -> [u64; SEED_SIZE] {
 
 /// Create an acknowledgement message
 /// to ping back the Agent.
+#[allow(dead_code)]
 pub fn ack_msg() -> MultiMessage {
     use scaii_defs::protos::{Ack, ScaiiPacket};
     use scaii_defs::protos;

--- a/demos/tower_agent.py
+++ b/demos/tower_agent.py
@@ -2,6 +2,9 @@ from scaii.env.sky_rts.env.scenarios.tower_example import TowerExample
 import numpy as np
 
 env = TowerExample()
+print("Possible reward types:", env.reward_types())
+print("Possible actions:", env.actions())
+print("Action description", env.action_desc())
 
 for i in range(0, 2):
     print("episode", i)
@@ -20,3 +23,4 @@ for i in range(0, 2):
         s = env.act(noop)
 
     print("Reward is:", s.reward, "Terminal?:", s.is_terminal())
+    print("With types:", s.typed_reward)

--- a/game_wrapper/python/env/scenarios/tower_example.py
+++ b/game_wrapper/python/env/scenarios/tower_example.py
@@ -10,16 +10,10 @@ class TowerAction(MoveList):
         if quadrant not in [1, 2, 3, 4]:
             raise InvalidActionError(quadrant)
 
+        self.move_list = []
+
         super().move_unit(
             self.state.id_list[0], "attack", self.state.id_list[quadrant])
-
-    def actions(self):
-        return {
-            'bottom_right': 1,
-            'top_right': 2,
-            'bottom_left': 3,
-            'top_left': 4,
-        }
 
     def to_proto(self, packet, skip=True):
         super().to_proto(packet, skip, skip_lua=None)
@@ -37,8 +31,20 @@ class TowerExample(SkyRtsEnv):
 
         return act
 
+    def actions(self):
+        return {
+            'actions': {
+                'bottom_right': 1,
+                'top_right': 2,
+                'bottom_left': 3,
+                'top_left': 4,
+            },
+            'desc': "Use action.attack_quadrant(1-4) to select \
+                a quadrant to attack"
+        }
+
 
 class InvalidActionError(Exception):
     def __init__(self, action_taken):
-        Exception.__init__(
-            "Invalid action, must be in range 1-4 (inclusive). Got {}".format(action_taken))
+        Exception.__init__(self,
+                           "Invalid action, must be in range 1-4 (inclusive). Got {}".format(action_taken))


### PR DESCRIPTION
Adds support for typed rewards in Lua. To use them,
you must declare each possible reward in the init,
and either explicitly set all non-default rewards to 0
or override their values.

This also communicates environment descriptors other
than typed rewards.