### PR TITLE
Fix replays failing after terminal state

### DIFF
--- a/backend/src/engine/resources/mod.rs
+++ b/backend/src/engine/resources/mod.rs
@@ -80,7 +80,7 @@ pub struct Step(pub usize);
 pub struct MaxStep(pub Option<usize>);
 
 /// Is this the final frame of the scenario?
-#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct Terminal(pub bool);
 
 /// Time since the last update, in seconds (fixed to one sixtieth of a second for our purposes).

--- a/backend/src/engine/systems/serde/de.rs
+++ b/backend/src/engine/systems/serde/de.rs
@@ -6,7 +6,7 @@ use specs::error::NoError;
 
 use rand::Isaac64Rng;
 
-use engine::resources::{LuaPath, SerializeBytes};
+use engine::resources::{LuaPath, SerializeBytes, Terminal};
 
 #[derive(SystemData)]
 pub struct DeserializeSystemData<'a> {
@@ -14,6 +14,7 @@ pub struct DeserializeSystemData<'a> {
 
     rng: FetchMut<'a, Isaac64Rng>,
     lua_path: FetchMut<'a, LuaPath>,
+    terminal: FetchMut<'a, Terminal>,
 
     decode: Fetch<'a, SerializeBytes>,
 }
@@ -41,5 +42,6 @@ impl<'a> System<'a> for DeserializeSystem {
 
         *world.lua_path = tar.lua_path;
         *world.rng = tar.rng;
+        *world.terminal = tar.terminal;
     }
 }

--- a/backend/src/engine/systems/serde/mod.rs
+++ b/backend/src/engine/systems/serde/mod.rs
@@ -6,9 +6,9 @@ pub use self::ser::SerializeSystem;
 pub use self::de::DeserializeSystem;
 pub use self::de_collision::RedoCollisionSys;
 
-use engine::resources::LuaPath;
-use engine::components::{Attack, Color, FactionId, Hp, Movable, Move, MovedFlag, Pos, Shape,
-                         Speed, Static, UnitTypeTag};
+use engine::resources::{LuaPath, Terminal};
+use engine::components::{Attack, Color, FactionId, Hp, Movable, Move, Pos, Shape, Speed, Static,
+                         UnitTypeTag};
 use rand::Isaac64Rng;
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -16,6 +16,7 @@ struct SerTarget {
     components: Vec<u8>,
     lua_path: LuaPath,
     rng: Isaac64Rng,
+    terminal: Terminal,
 }
 
 type SerComponents = (

--- a/backend/src/engine/systems/serde/ser.rs
+++ b/backend/src/engine/systems/serde/ser.rs
@@ -6,7 +6,7 @@ use specs::error::NoError;
 
 use rand::Isaac64Rng;
 
-use engine::resources::{LuaPath, SerializeBytes};
+use engine::resources::{LuaPath, SerializeBytes, Terminal};
 
 #[derive(SystemData)]
 pub struct SerializeSystemData<'a> {
@@ -14,6 +14,7 @@ pub struct SerializeSystemData<'a> {
 
     rng: FetchMut<'a, Isaac64Rng>,
     lua_path: Fetch<'a, LuaPath>,
+    terminal: Fetch<'a, Terminal>,
 
     out: FetchMut<'a, SerializeBytes>,
 }
@@ -43,6 +44,7 @@ impl<'a> System<'a> for SerializeSystem {
             components: tar,
             lua_path: world.lua_path.clone(),
             rng: world.rng.clone(),
+            terminal: *world.terminal,
         };
 
         let mut out = Serializer::new(out);


### PR DESCRIPTION
Fixes #20

The game previously failed to handle deserializing if the game
was in a terminal state due to not storing whether a state was terminal
in the serialized information. That adds that field.